### PR TITLE
[chore]: Upgrade base Ray version to 2.55

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ from ray_ascend.collective import HCCLGroup
 from ray_ascend.direct_transport import HCCLTensorTransport
 
 ray.register_collective_backend("HCCL", HCCLGroup)
-register_tensor_transport("HCCL", ["npu"], HCCLTensorTransport)
+register_tensor_transport("HCCL", ["npu"], HCCLTensorTransport, torch.Tensor)
 
 
 @ray.remote(resources={"NPU": 1})
@@ -112,7 +112,7 @@ provided) using Ray objects.
 import ray
 from ray_ascend.direct_transport import YRTensorTransport
 from ray.experimental import register_tensor_transport
-register_tensor_transport("YR", ["npu", "cpu"], YRTensorTransport)
+register_tensor_transport("YR", ["npu", "cpu"], YRTensorTransport, torch.Tensor)
 
 @ray.remote(resources={"NPU": 1})
 class RayActor:

--- a/docs/user_guide/api_reference.md
+++ b/docs/user_guide/api_reference.md
@@ -60,8 +60,9 @@ YRTensorTransport()
 Register YR tensor transport with:
 
 ```python
+import torch
 from ray.experimental import register_tensor_transport
 from ray_ascend.direct_transport import YRTensorTransport
 
-register_tensor_transport("YR", ["npu", "cpu"], YRTensorTransport)
+register_tensor_transport("YR", ["npu", "cpu"], YRTensorTransport, torch.Tensor)
 ```

--- a/docs/user_guide/yr_transport.md
+++ b/docs/user_guide/yr_transport.md
@@ -36,7 +36,7 @@ from ray_ascend.direct_transport import YRTensorTransport
 ray.init()
 
 # Register YR tensor transport for both CPU and NPU tensors
-register_tensor_transport("YR", ["npu", "cpu"], YRTensorTransport)
+register_tensor_transport("YR", ["npu", "cpu"], YRTensorTransport, torch.Tensor)
 
 @ray.remote(resources={"NPU": 1})
 class NPUActor:
@@ -91,7 +91,7 @@ from ray_ascend.direct_transport import YRTensorTransport
 
 # Register both backends
 ray.register_collective_backend("HCCL", HCCLGroup)
-register_tensor_transport("YR", ["npu", "cpu"], YRTensorTransport)
+register_tensor_transport("YR", ["npu", "cpu"], YRTensorTransport, torch.Tensor)
 
 @ray.remote(resources={"NPU": 1})
 class RayActor:

--- a/ray_ascend/collective/hccl_collective_group.py
+++ b/ray_ascend/collective/hccl_collective_group.py
@@ -359,13 +359,28 @@ class HCCLGroup(BaseGroup):
             None
         """
 
+        input_flattened = [_flatten_for_scatter_gather(tensor_list, copy=False)]
+
+        input_tensor = self._validate_tensor(input_flattened[0])
+        output_tensor = self._validate_tensor(tensor)
+        comm, stream = self._validate_collective_state()
+
+        # Copy tensors and record event for proper stream synchronization
+        copy_stream = torch.npu.current_stream()
+        for j, in_tensor in enumerate(tensor_list):
+            input_flattened[0][j].copy_(in_tensor)
+        copy_event = torch.npu.Event()
+        copy_event.record(copy_stream)
+
         def collective_fn(
             input_tensor: torch.Tensor, output_tensor: torch.Tensor, comm, stream
         ):
             with torch.npu.device(input_tensor.device):
-                # HcclResult HcclReduceScatter(void *sendBuf, void *recvBuf, uint64_t recvCount, HcclDataType dataType, HcclReduceOp op, HcclComm comm, aclrtStream stream)
+                # Wait for copy operations to complete
+                stream.wait_event(copy_event)
                 current_stream = torch.npu.current_stream()
                 stream.wait_stream(current_stream)
+                # HcclResult HcclReduceScatter(void *sendBuf, void *recvBuf, uint64_t recvCount, HcclDataType dataType, HcclReduceOp op, HcclComm comm, aclrtStream stream)
                 exec_result = self.libhccl.HcclReduceScatter(
                     buffer_type(input_tensor.data_ptr()),
                     buffer_type(output_tensor.data_ptr()),
@@ -378,17 +393,15 @@ class HCCLGroup(BaseGroup):
                 event = torch.npu.Event()
                 event.record(stream)
                 current_stream.wait_event(event)
-                logger.debug(f"HcclReduceScatter execute result : {exec_result}")
+            logger.debug(f"HcclReduceScatter execute result : {exec_result}")
 
-        input_flattened = [_flatten_for_scatter_gather(tensor_list, copy=False)]
-
-        for j, in_tensor in enumerate(tensor_list):
-            input_flattened[0][j].copy_(in_tensor)
-
-        input_tensor = self._validate_tensor(input_flattened[0])
-        output_tensor = self._validate_tensor(tensor)
-        comm, stream = self._validate_collective_state()
         collective_fn(input_tensor, output_tensor, comm, stream)
+
+        # Record completion event on HCCL stream and wait on caller's current stream
+        # This ensures output_tensor is ready before caller reads it
+        completion_event = torch.npu.Event()
+        completion_event.record(stream)
+        torch.npu.current_stream().wait_event(completion_event)
 
     def send(
         self, tensor: torch.Tensor, send_options: SendOptions = SendOptions()

--- a/ray_ascend/direct_transport/yr_tensor_transport.py
+++ b/ray_ascend/direct_transport/yr_tensor_transport.py
@@ -3,7 +3,7 @@ import os
 import pickle
 import uuid
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import ray
 import torch
@@ -109,9 +109,7 @@ class YRTensorTransport(TensorTransportManager):
         ) -> bool:
             # Check if yr.datasystem worker is healthy
             try:
-                from ray.experimental.gpu_object_manager.util import (
-                    get_tensor_transport_manager,
-                )
+                from ray.experimental.rdt.util import get_tensor_transport_manager
 
                 return (  # type: ignore[no-any-return]
                     get_tensor_transport_manager("YR")
@@ -172,7 +170,7 @@ class YRTensorTransport(TensorTransportManager):
 
         return YRTransportMetadata(
             tensor_meta=tensor_meta,
-            tensor_device=device,
+            tensor_device=device.type,
             ds_serialized_keys=serialized_keys,
         )
 
@@ -189,16 +187,20 @@ class YRTensorTransport(TensorTransportManager):
         obj_id: str,
         tensor_transport_metadata: TensorTransportMetadata,
         communicator_metadata: CommunicatorMetadata,
+        target_buffers: Optional[List[Any]] = None,
     ) -> List["torch.Tensor"]:
-        # create empty tensors from meta data
-        tensors = []
-        device = tensor_transport_metadata.tensor_device
-        for meta_data in tensor_transport_metadata.tensor_meta:
-            shape, dtype = meta_data
-            import torch
+        # Use pre-allocated target buffers if provided, otherwise create empty tensors
+        if target_buffers is not None:
+            tensors = target_buffers
+        else:
+            tensors = []
+            device = tensor_transport_metadata.tensor_device
+            for meta_data in tensor_transport_metadata.tensor_meta:
+                shape, dtype = meta_data
+                import torch
 
-            tensor = torch.empty(size=shape, dtype=dtype, device=device)
-            tensors.append(tensor)
+                tensor = torch.empty(size=shape, dtype=dtype, device=device)
+                tensors.append(tensor)
 
         assert isinstance(tensor_transport_metadata, YRTransportMetadata)
         assert isinstance(communicator_metadata, YRCommunicatorMetadata)
@@ -206,7 +208,7 @@ class YRTensorTransport(TensorTransportManager):
         serialized_keys = tensor_transport_metadata.ds_serialized_keys
         keys = pickle.loads(serialized_keys)
 
-        device_type = device.type
+        device_type = tensor_transport_metadata.tensor_device
         ds_client = self.get_ds_client(device_type)
         try:
             ds_client.get(keys=keys, tensors=tensors)
@@ -234,10 +236,11 @@ class YRTensorTransport(TensorTransportManager):
         self,
         obj_id: str,
         tensor_transport_meta: TensorTransportMetadata,
+        tensors: Optional[List[Any]] = None,
     ):
         assert isinstance(tensor_transport_meta, YRTransportMetadata)
         serialized_keys = tensor_transport_meta.ds_serialized_keys
-        device_type = tensor_transport_meta.tensor_device.type
+        device_type = tensor_transport_meta.tensor_device
         if serialized_keys is not None:
             keys = pickle.loads(serialized_keys)
             ds_client = self.get_ds_client(device_type)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ray[default]>=2.54.0
+ray[default]>=2.55.0

--- a/tests/benchmarks/direct_transport_perftest.py
+++ b/tests/benchmarks/direct_transport_perftest.py
@@ -19,7 +19,7 @@ from ray_ascend.utils import (
     start_etcd,
 )
 
-register_tensor_transport("YR", ["npu", "cpu"], YRTensorTransport)
+register_tensor_transport("YR", ["npu", "cpu"], YRTensorTransport, torch.Tensor)
 
 # Add parent directory to sys.path for importing base_perftest
 sys.path.insert(0, str(Path(__file__).parent))
@@ -48,11 +48,6 @@ def check_npu_is_available():
             raise RuntimeError(
                 "NPU device specified but not available. Please check your environment."
             )
-
-
-def yr_is_available_in_actor(actor: "ray.actor.ActorHandle") -> bool:
-    gpu_object_manager = ray._private.worker.global_worker.gpu_object_manager
-    return bool(gpu_object_manager.actor_has_tensor_transport(actor, "YR"))
 
 
 def load_config_from_file(config_file: str) -> dict:
@@ -266,7 +261,7 @@ class DataSystemActor:
 class YRTensorTransportActor:
 
     def __init__(self, config: argparse.Namespace, node_ip: Optional[str] = None):
-        register_tensor_transport("YR", ["npu", "cpu"], YRTensorTransport)
+        register_tensor_transport("YR", ["npu", "cpu"], YRTensorTransport, torch.Tensor)
         self.config = config
         self.node_ip = node_ip
         self.data: Optional[torch.Tensor] = None

--- a/tests/direct_transport/test_yr_transport.py
+++ b/tests/direct_transport/test_yr_transport.py
@@ -126,7 +126,7 @@ class TestCPUTransport:
 
         assert isinstance(meta, YRTransportMetadata)
         assert len(meta.tensor_meta) == len(cpu_tensors)
-        assert meta.tensor_device.type == "cpu"
+        assert meta.tensor_device == "cpu"
         assert isinstance(meta.ds_serialized_keys, (bytes, bytearray))
 
         mock_client.mcreate.assert_called_once()
@@ -217,7 +217,7 @@ class TestNPUTransport:
 
         assert isinstance(meta, YRTransportMetadata)
         assert len(meta.tensor_meta) == len(npu_tensors)
-        assert meta.tensor_device.type == "npu"
+        assert meta.tensor_device == "npu"
         assert isinstance(meta.ds_serialized_keys, (bytes, bytearray))
 
         mock_client.dev_mset.assert_called_once()


### PR DESCRIPTION
## Description
Upgrade base Ray version to 2.55 to adapt to the new RDT API breaking changes. Ray 2.55 introduced breaking changes including the `register_tensor_transport` function now requiring a `data_type` parameter, the `TensorTransportManager` interface changes with new parameters for `recv_multiple_tensors` and `garbage_collect`, and the module path change from `ray.experimental.gpu_object_manager` to `ray.experimental.rdt`.

## Changes
- Updated import path in `YRTensorTransport.actor_has_tensor_transport`: `ray.experimental.gpu_object_manager.util` →`ray.experimental.rdt.util`
 - Added target_buffers: `Optional[List[Any]]` parameter to `recv_multiple_tensors` method signature
 - Added tensors: `Optional[List[Any]]` parameter to `garbage_collect` method signature with proper type annotation
 - Changed tensor_device from `torch.device` object to device type string (`device.type`) to match Ray's `device_match_transport` check
 - Added `torch.Tensor` as data_type to all `register_tensor_transport` calls across the codebase
 - Removed unused `yr_is_available_in_actor function` that referenced deprecated module
 - Fixed reducescatter stream synchronization in HCCL collective group with event-based synchronization before and after HCCL operations
 - Updated tests to expect string device type instead of `torch.device` object

## Related issues
Fixes #47 #37 