### PR TITLE
[docs] Clarify etcd is optional and unify OpenYuanrong naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           curl -s -L https://mirrors.huaweicloud.com/etcd/v3.6.5/etcd-v3.6.5-linux-arm64.tar.gz -o etcd-v3.6.5-linux-arm64.tar.gz
           tar -xzf etcd-v3.6.5-linux-arm64.tar.gz
           mv etcd-v3.6.5-linux-arm64/etcd /usr/local/bin/
-      - name: Install yuanrong-datasystem
+      - name: Install openyuanrong-datasystem
         run: |
           pip${{ matrix.python-version }} install "openyuanrong-datasystem>=0.8.0"
       - name: Run performance test (etcd mode)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ ray.get(result)
 
 ### Transport Ascend NPU Tensors via [HCCS](https://www.hiascend.com/document/detail/zh/Glossary/gls/gls_0001.html#ZH-CN_TOPIC_0000002210355753__section665813471086) and CPU Tensors via RDMA
 
-[OpenYuanRong DataSystem](https://pages.openeuler.openatom.cn/openyuanrong-datasystem/docs/zh-cn/latest/index.html)
+[OpenYuanrong DataSystem](https://pages.openeuler.openatom.cn/openyuanrong-datasystem/docs/zh-cn/latest/index.html)
 (`YR`) allows users to transport NPU tensors (via HCCS) and CPU tensors (via RDMA if
 provided) using Ray objects.
 

--- a/docs/developer_guide/index.md
+++ b/docs/developer_guide/index.md
@@ -32,8 +32,7 @@ Before starting development, you need to set up your environment. Refer to
   tensor for transmission.
 - **Choose Installation Type**:
     - **Basic Installation**: `pip install -e .`
-    - **With YR Support**: `pip install -e ".[yr]"` (includes YuanRong direct tensor
-      transport)
+    - **With YR Support**: `pip install -e ".[yr]"` (includes YR direct tensor transport)
     - **Full Installation**: `pip install -e ".[all]"` (all features for development and
       testing)
 
@@ -61,7 +60,7 @@ The ray-ascend project is organized as follows:
 ```
 ray_ascend/
 ├── collective/              # HCCL collective communication
-└── direct_transport/        # YuanRong direct tensor transport
+└── direct_transport/        # YR direct tensor transport
 
 
 tests/
@@ -73,7 +72,7 @@ tests/
 **Main Components:**
 
 - **collective/**: HCCL-based collective communication group implementation
-- **direct_transport/**: YuanRong direct tensor transport implementation
+- **direct_transport/**: YR direct tensor transport implementation
 - **tests/**: Comprehensive test suite using pytest
 
 ## Coding Standards and Submission
@@ -194,7 +193,7 @@ Before submitting, please ensure:
 
 ## Performance Testing
 
-For instructions on running performance benchmarks for YuanRong Direct Transport, see
+For instructions on running performance benchmarks for YR Direct Transport, see
 [Performance Testing Guide](performance_testing.md).
 
 ## Documentation

--- a/docs/developer_guide/performance_testing.md
+++ b/docs/developer_guide/performance_testing.md
@@ -2,15 +2,15 @@
 
 > Last updated: 03/30/2026
 
-This guide explains how to run performance tests for ray-ascend, including YuanRong (YR)
-Direct Transport and HCCL collective communication performance tests.
+This guide explains how to run performance tests for ray-ascend, including OpenYuanrong
+(YR) Direct Transport and HCCL collective communication performance tests.
 
 ## Overview
 
 The performance test suite is located in `tests/benchmarks/` and supports the following
 test types:
 
-- **YR Direct Transport**: Tests YuanRong direct tensor transport performance
+- **YR Direct Transport**: Tests YR direct tensor transport performance
 - **HCCL Collective Communication**: Tests HCCL collective operations performance
   (Coming Soon)
 
@@ -52,8 +52,8 @@ ______________________________________________________________________
 
 ### Overview
 
-Tests YuanRong direct tensor transport performance between Ray actors. This test
-measures the throughput and latency of tensor transfers using YR Direct Transport.
+Tests YR direct tensor transport performance between Ray actors. This test measures the
+throughput and latency of tensor transfers using YR Direct Transport.
 
 ### Additional Prerequisites
 

--- a/docs/developer_guide/setup.md
+++ b/docs/developer_guide/setup.md
@@ -2,13 +2,13 @@
 
 > _Last updated: 03/09/2026_
 
-We provide installation instructions for YuanRong direct transport and HCCL collective
+We provide installation instructions for YR direct transport and HCCL collective
 communication, and you can selectively install the relevant dependencies as needed.
 
 ### Install CANN
 
 If you have NPU devices and want to accelerate the transmission of NPU tensor by
-**YuanRong** or **HCCL**, you need to install **Ascend CANN Toolkit**.
+**OpenYuanrong** or **HCCL**, you need to install **Ascend CANN Toolkit**.
 
 > **CANN** (Compute Architecture for Neural Networks) is a heterogeneous computing
 > architecture launched by Huawei for AI scenarios.
@@ -70,7 +70,7 @@ python -m build --wheel
 pip install dist/*.whl
 ```
 
-## Install ray-ascend with YuanRong
+## Install ray-ascend with OpenYuanrong
 
 If you want to use
 [YR](https://pages.openeuler.openatom.cn/openyuanrong-datasystem/docs/zh-cn/latest/index.html)
@@ -90,10 +90,13 @@ Verify the installation by checking for the `dscli` command-line tool.
 dscli --version
 ```
 
-### Install etcd
+### Install etcd (Optional, for etcd Mode)
 
-OpenYuanRong DataSystem relies on etcd for cluster coordination. Download and install
-etcd from the official releases:
+OpenYuanrong DataSystem supports two initialization modes: `metastore` (default, no
+external dependencies) and `etcd` (requires external etcd service). Etcd setup is only
+needed if you choose to use etcd mode.
+
+Download and install etcd from the official releases:
 [ETCD GitHub Releases](https://github.com/etcd-io/etcd/releases)
 
 ```bash

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -11,7 +11,7 @@ nav:
       - Overview: user_guide/index.md
       - Installation: user_guide/installation.md
       - HCCL Collective Communication: user_guide/hccl_collective.md
-      - YuanRong Direct Transport: user_guide/yr_transport.md
+      - YR Direct Transport: user_guide/yr_transport.md
       - API Reference: user_guide/api_reference.md
       - Best Practices: user_guide/best_practices.md
   - Developer Guide:

--- a/docs/user_guide/api_reference.md
+++ b/docs/user_guide/api_reference.md
@@ -28,7 +28,7 @@ HCCLGroup(world_size: int, rank: int, group_name: str)
 
 ## YRTensorTransport
 
-The main class for YuanRong direct tensor transport.
+The main class for YR direct tensor transport.
 
 ### Constructor
 

--- a/docs/user_guide/best_practices.md
+++ b/docs/user_guide/best_practices.md
@@ -51,7 +51,7 @@ current when the `HCCLGroup` was created.
 
 ### YR Transport Issues
 
-**Problem**: "YuanRong datasystem worker env not set"
+**Problem**: "YR DS worker env not set"
 
 **Solution**: Set the required environment variables:
 
@@ -68,7 +68,7 @@ export YR_DS_WORKER_PORT="31502"
 pip install "ray-ascend[yr]"
 ```
 
-**Problem**: "Failed to initialize YuanRong Datasystem client"
+**Problem**: "Failed to initialize YR DS client"
 
 **Solution**:
 

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -12,8 +12,8 @@ of ray-ascend's key features:
 
 - **HCCL Collective Communication**: Distributed collective operations across Ray actors
   using Huawei Collective Communication Library
-- **YuanRong Direct Transport**: Efficient zero-copy transfer of CPU and NPU tensors
-  between Ray actors
+- **YR Direct Transport**: Efficient zero-copy transfer of CPU and NPU tensors between
+  Ray actors
 
 ## Prerequisites
 
@@ -30,7 +30,7 @@ Optional dependencies for specific features:
 ## Quick Start
 
 ```bash
-# Install with YuanRong support
+# Install with YR support
 pip install "ray-ascend[yr]"
 ```
 
@@ -38,7 +38,7 @@ pip install "ray-ascend[yr]"
 
 - [Installation](installation.md): Detailed installation and setup instructions
 - [HCCL Collective Communication](hccl_collective.md): Collective operations guide
-- [YuanRong Direct Transport](yr_transport.md): Tensor transport guide
+- [YR Direct Transport](yr_transport.md): Tensor transport guide
 - [API Reference](api_reference.md): Complete API documentation
 - [Best Practices](best_practices.md): Best practices, troubleshooting, and FAQ
 
@@ -46,6 +46,6 @@ pip install "ray-ascend[yr]"
 
 - [Ray Documentation](https://docs.ray.io/)
 - [Ascend Documentation](https://www.hiascend.com/)
-- [OpenYuanRong DataSystem Documentation](https://pages.openeuler.openatom.cn/openyuanrong-datasystem/docs/zh-cn/latest/)
+- [OpenYuanrong DataSystem Documentation](https://pages.openeuler.openatom.cn/openyuanrong-datasystem/docs/zh-cn/latest/)
 - [GitHub Repository](https://github.com/Ascend/ray-ascend)
 - [Developer Guide](../developer_guide/index.md)

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> _Last updated: 03/24/2026_
+> _Last updated: 04/21/2026_
 
 ## Installation Options
 
@@ -12,9 +12,9 @@ Install the base package with HCCL collective communication support:
 pip install ray-ascend
 ```
 
-### With YuanRong Direct Transport Support
+### With YR Direct Transport Support
 
-Install with YuanRong (YR) direct tensor transport support:
+Install with OpenYuanrong (YR) direct tensor transport support:
 
 ```bash
 pip install "ray-ascend[yr]"
@@ -58,10 +58,13 @@ After CANN installation, confirm the toolkit path exists:
 ls /usr/local/Ascend/ascend-toolkit/latest
 ```
 
-## Etcd Setup (for YR Transport)
+## Etcd Setup (Optional, for YR Transport etcd Mode)
 
-OpenYuanRong DataSystem relies on etcd for cluster coordination. Download and install
-etcd from the official releases:
+OpenYuanrong DataSystem supports two initialization modes: `metastore` (default, no
+external dependencies) and `etcd` (requires external etcd service). Etcd setup is only
+needed if you choose to use etcd mode.
+
+Download and install etcd from the official releases:
 [ETCD GitHub Releases](https://github.com/etcd-io/etcd/releases)
 
 ```bash
@@ -83,12 +86,9 @@ etcdctl version
 
 ## Environment Variables for YR Transport
 
-Set these environment variables before using YuanRong direct transport:
-
-```bash
-export YR_DS_WORKER_HOST="127.0.0.1"
-export YR_DS_WORKER_PORT="31502"
-```
+For YR transport environment variables configuration, see
+[Environment Variables](yr_transport.md#environment-variables) in the YR Transport
+guide.
 
 Verify the YR installation by checking for the `dscli` command-line tool:
 

--- a/docs/user_guide/yr_transport.md
+++ b/docs/user_guide/yr_transport.md
@@ -1,13 +1,13 @@
-# YuanRong Direct Tensor Transport
+# YR Direct Tensor Transport
 
 > _Last updated: 04/20/2026_
 
-YuanRong (YR) direct transport enables efficient zero-copy transfer of both CPU and NPU
-tensors between Ray actors.
+OpenYuanrong (YR) direct transport enables efficient zero-copy transfer of both CPU and
+NPU tensors between Ray actors.
 
 ## Features
 
-- **Zero-copy transfer**: Efficient memory sharing via OpenYuanRong DataSystem
+- **Zero-copy transfer**: Efficient memory sharing via OpenYuanrong DataSystem
 - **Dual device support**: Works with both CPU and NPU tensors
 - **One-sided communication**: Pull-based model for efficient transfers
 - **Automatic garbage collection**: Cleans up resources when no longer needed
@@ -17,7 +17,7 @@ tensors between Ray actors.
 Before using YR transport, ensure you have:
 
 1. Installed ray-ascend with YR support: `pip install "ray-ascend[yr]"`
-1. Installed dscli: `pip install openyuanrong-datasystem>=0.8.0`
+1. Installed dscli: `pip install "openyuanrong-datasystem>=0.8.0"`
 
 ## Ray Cluster Setup
 
@@ -121,6 +121,7 @@ from ray_ascend import register_yr_tensor_transport
 
 os.environ["YR_DS_INIT_MODE"] = "metastore"
 os.environ["YR_DS_WORKER_PORT"] = 31501
+os.environ["YR_DS_METASTORE_PORT"] = 2379
 os.environ["YR_DS_WORKER_ARGS"] = "--shared_memory_size_mb 16384 --remote_h2d_device_ids 0,1,2,3"
 
 ray.init()

--- a/ray_ascend/direct_transport/yr_tensor_transport.py
+++ b/ray_ascend/direct_transport/yr_tensor_transport.py
@@ -95,13 +95,11 @@ class YRTensorTransport(TensorTransportManager):
             else:
                 self._ds_client["cpu"] = CPUClientAdapter(host, port)
             self._ds_client[device_type].init()
-            logger.info(
-                f"Initialized YuanRong Datasystem client for {device_type} at {host}:{port}"
-            )
+            logger.info(f"Initialized YR DS client for {device_type} at {host}:{port}")
         except Exception as e:
             self._ds_client.pop(device_type, None)
             raise RuntimeError(
-                f"Failed to initialize YuanRong Datasystem client at {host}:{port}. Error: {e}"
+                f"Failed to initialize YR DS client at {host}:{port}. Error: {e}"
             ) from e
 
         return self._ds_client[device_type]
@@ -225,7 +223,7 @@ class YRTensorTransport(TensorTransportManager):
         communicator_metadata: CommunicatorMetadata,
     ):
         raise NotImplementedError(
-            "Datasystem transport does not support send_multiple_tensors,"
+            "YR DS transport does not support send_multiple_tensors,"
             "since it is a one-sided transport."
         )
 
@@ -255,4 +253,4 @@ class YRTensorTransport(TensorTransportManager):
         obj_id: str,
         communicator_metadata: CommunicatorMetadata,
     ):
-        raise NotImplementedError("YuanRong transport does not support aborting.")
+        raise NotImplementedError("YR transport does not support aborting.")

--- a/ray_ascend/utils/yr_utils.py
+++ b/ray_ascend/utils/yr_utils.py
@@ -140,7 +140,7 @@ def start_datasystem_worker(
     is_head: bool = False,
     worker_args: Optional[str] = None,
 ) -> str:
-    """Start Yuanrong datasystem worker (unified function with init_mode parameter).
+    """Start YR DS worker (unified function with init_mode parameter).
 
     Args:
         worker_address: Worker address in format "host:port"
@@ -158,7 +158,7 @@ def start_datasystem_worker(
     """
     if not shutil.which("dscli"):
         raise RuntimeError(
-            "dscli executable not found in PATH. Please run `pip install openyuanrong-datasystem>=0.8.0`."
+            'dscli executable not found in PATH. Please run `pip install "openyuanrong-datasystem>=0.8.0"`.'
         )
 
     # Build base command
@@ -191,9 +191,7 @@ def start_datasystem_worker(
     if worker_args:
         cmd.extend(worker_args.split())
 
-    logger.info(
-        f"Starting Yuanrong datasystem ({init_mode}, {node_type}) at {worker_address}"
-    )
+    logger.info(f"Starting YR DS worker ({init_mode}, {node_type}) at {worker_address}")
 
     # Build environment with ASCEND_RT_VISIBLE_DEVICES if specified (for NPU)
     env = None
@@ -219,18 +217,18 @@ def start_datasystem_worker(
 
     if ds_result.returncode == 0 and "[  OK  ]" in ds_result.stdout:
         logger.info(
-            f"dscli started Yuanrong datasystem ({init_mode}, {node_type}) at {worker_address} successfully"
+            f"dscli started YR DS worker ({init_mode}, {node_type}) at {worker_address} successfully"
         )
         return worker_address
 
     raise RuntimeError(
-        f"Failed to start datasystem ({init_mode}, {node_type}) at {worker_address}. "
+        f"Failed to start YR DS worker ({init_mode}, {node_type}) at {worker_address}. "
         f"Return code: {ds_result.returncode}, Output: {ds_result.stdout}"
     )
 
 
 def stop_datasystem_worker(worker_address: str) -> None:
-    """Stop Yuanrong datasystem worker.
+    """Stop YR DS worker.
 
     Args:
         worker_address: Worker address in format "host:port"
@@ -240,7 +238,7 @@ def stop_datasystem_worker(worker_address: str) -> None:
     """
     if not shutil.which("dscli"):
         raise RuntimeError(
-            "dscli executable not found in PATH. Please run `pip install openyuanrong-datasystem>=0.8.0`."
+            'dscli executable not found in PATH. Please run `pip install "openyuanrong-datasystem>=0.8.0"`.'
         )
 
     try:
@@ -303,7 +301,7 @@ def _parse_remote_h2d_device_ids(worker_args: str) -> Optional[str]:
 
 @ray.remote(num_cpus=0.1)
 class DataSystemActor:
-    """Ray actor to manage Yuanrong datasystem worker on a node.
+    """Ray actor to manage YR DS worker on a node.
 
     Supports both etcd and metastore initialization modes.
 
@@ -374,7 +372,7 @@ class DataSystemActor:
             RuntimeError: If dscli command fails
         """
         assert self._worker_address is not None
-        logger.info(f"Starting datasystem worker at {self._worker_address}...")
+        logger.info(f"Starting YR DS worker at {self._worker_address}...")
 
         worker_address = start_datasystem_worker(
             worker_address=self._worker_address,
@@ -392,7 +390,7 @@ class DataSystemActor:
         # Start reaper process for Parent Process Death Detection cleanup
         self._start_reaper(worker_address)
 
-        logger.info(f"Datasystem worker started successfully at {self._worker_address}")
+        logger.info(f"YR DS worker started successfully at {self._worker_address}")
         return worker_address
 
     def _start_reaper(self, worker_address: str) -> None:
@@ -510,7 +508,7 @@ class YRBackendCoordinator:
                     f"Failed to remove placement group after readiness timeout: {cleanup_error}"
                 )
             raise RuntimeError(
-                "Timed out waiting for Yuanrong placement group to become ready. "
+                "Timed out waiting for YR placement group to become ready. "
                 f"Requested strategy=STRICT_SPREAD, bundles={bundles}. "
                 "This may be due to insufficient cluster capacity."
             ) from e
@@ -522,7 +520,7 @@ class YRBackendCoordinator:
                     f"Failed to remove placement group after scheduling failure: {cleanup_error}"
                 )
             raise RuntimeError(
-                f"Failed to create Yuanrong placement group. "
+                f"Failed to create YR placement group. "
                 f"Requested strategy=STRICT_SPREAD, bundles={bundles}."
             ) from e
 
@@ -578,7 +576,7 @@ class YRBackendCoordinator:
         if self._placement_group:
             try:
                 ray.util.remove_placement_group(self._placement_group)
-                logger.info("Removed Yuanrong placement group")
+                logger.info("Removed YR placement group")
             except Exception as e:
                 logger.warning(f"Failed to remove placement group: {e}")
 


### PR DESCRIPTION
## Description

  - Clarify that etcd setup is optional for YR transport (only needed for etcd mode, metastore mode is default with no external dependencies)
  - Unify "OpenYuanrong" naming across all documentation files
  - Update environment variables section in installation.md to reference yr_transport.md instead of listing outdated env vars
  - Fix pip install commands to properly quote version constraints (e.g., `"openyuanrong-datasystem>=0.8.0"`)

  ## Files Changed

  - `README.md`: OpenYuanrong naming
  - `docs/developer_guide/setup.md`: etcd optional clarification, naming
  - `docs/user_guide/installation.md`: etcd optional, env vars reference
  - `docs/user_guide/yr_transport.md`: naming, pip command fix
  - `docs/user_guide/index.md`: naming
  - `ray_ascend/utils/yr_utils.py`: pip command fix in error messages