### PR TITLE
[ci] Update publish workflow and dependency ranges

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,6 @@ on:
   push:
     tags:
       - "v*"
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to publish (without v prefix, e.g. 0.1.0)'
-        required: true
-        type: string
 
 jobs:
   build-package:
@@ -32,13 +26,8 @@ jobs:
 
       - name: Update version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "Using manual version: ${{ inputs.version }}"
-            python${{ matrix.python-version }} ci/update_version.py ${{ inputs.version }}
-          else
-            echo "Using tag version: ${GITHUB_REF#refs/tags/v}"
-            python${{ matrix.python-version }} ci/update_version.py
-          fi
+          echo "Using tag version: ${GITHUB_REF#refs/tags/v}"
+          python${{ matrix.python-version }} ci/update_version.py
 
       - name: Build package for Python ${{ matrix.python-version }}
         run: |
@@ -68,10 +57,12 @@ jobs:
         with:
           pattern: python-packages-*
           path: dist/
+          merge-multiple: true
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
+          tag_name: ${{ github.ref_name }}
           files: dist/*.whl
           generate_release_notes: true
         env:
@@ -89,6 +80,7 @@ jobs:
         with:
           pattern: python-packages-*
           path: dist/
+          merge-multiple: true
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ For performance benchmarks, see the [Performance Benchmark Report](./docs/develo
   - python >= 3.10, <= 3.11
   - CANN >= 8.2.rc1
   - torch >= 2.7.1; torch-npu >= 2.7.1.post2
-  - Ray (same version as ray-ascend)
+  - torch and torch-npu versions must be compatible with each other.
+  - ray >= 2.55.0
 
 ## Version
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ For performance benchmarks, see the [Performance Benchmark Report](./docs/develo
 - **OS Kernel**: Linux
 - **Python Dependencies**:
   - python >= 3.10, <= 3.11
-  - CANN == 8.2.rc1
-  - torch == 2.7.1, torch-npu == 2.7.1.post1
+  - CANN >= 8.2.rc1
+  - torch >= 2.7.1; torch-npu >= 2.7.1.post2
   - Ray (same version as ray-ascend)
 
 ## Version

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -26,6 +26,8 @@ Optional dependencies for specific features:
 
 - **CANN >= 8.2.rc1**: Required for NPU features (HCCL, NPU tensor transport)
 - **torch >= 2.7.1; torch-npu >= 2.7.1.post2**: Required for PyTorch NPU support
+- **torch and torch-npu version compatibility**: Use matching torch and torch-npu
+  versions.
 
 ## Quick Start
 

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -24,8 +24,8 @@ of ray-ascend's key features:
 
 Optional dependencies for specific features:
 
-- **CANN == 8.2.rc1**: Required for NPU features (HCCL, NPU tensor transport)
-- **torch == 2.7.1, torch-npu == 2.7.1.post1**: Required for PyTorch NPU support
+- **CANN >= 8.2.rc1**: Required for NPU features (HCCL, NPU tensor transport)
+- **torch >= 2.7.1; torch-npu >= 2.7.1.post2**: Required for PyTorch NPU support
 
 ## Quick Start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,18 +32,18 @@ version = {attr = "ray_ascend.__version__"}
 
 [project.optional-dependencies]
 test = [
-    "torch==2.7.1+cpu; platform_machine == 'x86_64'",
-    "torch==2.7.1; platform_machine == 'aarch64'",
-    "torch-npu==2.7.1.post2",
+    "torch>=2.7.1; platform_machine == 'x86_64'",
+    "torch>=2.7.1; platform_machine == 'aarch64'",
+    "torch-npu>=2.7.1.post2",
     "pytest>=7.0.0",
     "pytest-cov",
 ]
 
 yr = [
     "openyuanrong-datasystem>=0.8.0",
-    "torch==2.7.1+cpu; platform_machine == 'x86_64'",
-    "torch==2.7.1; platform_machine == 'aarch64'",
-    "torch-npu==2.7.1.post2",
+    "torch>=2.7.1; platform_machine == 'x86_64'",
+    "torch>=2.7.1; platform_machine == 'aarch64'",
+    "torch-npu>=2.7.1.post2",
     "requests",
 ]
 

--- a/ray_ascend/direct_transport/yr_tensor_transport.py
+++ b/ray_ascend/direct_transport/yr_tensor_transport.py
@@ -160,7 +160,7 @@ class YRTensorTransport(TensorTransportManager):
         if not gpu_object:
             raise ValueError("Tensor object list is empty.")
         serialized_keys = self.get_ds_metadata(gpu_object)
-        # We assume all tensors in one NPU/CPUobject have the same device type.
+        # We assume all tensors in one NPU/CPU object have the same device type.
         device = gpu_object[0].device
         for t in gpu_object:
             if t.device.type != device.type:

--- a/ray_ascend/direct_transport/yr_tensor_transport.py
+++ b/ray_ascend/direct_transport/yr_tensor_transport.py
@@ -28,7 +28,7 @@ class YRCommunicatorMetadata(CommunicatorMetadata):
 
 @dataclass
 class YRTransportMetadata(TensorTransportMetadata):
-    """Metadata for tensors stored in the GPU object store for YR transport.
+    """Metadata for tensors stored in the CPU/NPU object store for YR transport.
     Args:
         ds_serialized_keys: Serialized tensor keys for YR transport.
     """
@@ -158,9 +158,9 @@ class YRTensorTransport(TensorTransportManager):
 
         tensor_meta = []
         if not gpu_object:
-            raise ValueError("GPU object list is empty.")
+            raise ValueError("Tensor object list is empty.")
         serialized_keys = self.get_ds_metadata(gpu_object)
-        # We assume all tensors in one GPU object have the same device type.
+        # We assume all tensors in one NPU/CPUobject have the same device type.
         device = gpu_object[0].device
         for t in gpu_object:
             if t.device.type != device.type:


### PR DESCRIPTION
## Summary

This PR updates the release workflow and relaxes optional dependency requirements.

## Changes

- Remove manual `workflow_dispatch` publishing so releases are triggered only by `v*` tags.
- Fix artifact download paths by enabling `merge-multiple` before GitHub Release and PyPI publishing.
- Explicitly use the pushed tag name for GitHub Release creation.
- Relax `torch` and `torch-npu` optional dependency pins to minimum supported versions.
- Update README and user guide dependency docs for CANN, torch, and torch-npu.
