### PR TITLE
[ci] Fix publish version update in container

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Update version
         run: |
           echo "Using tag version: ${GITHUB_REF#refs/tags/v}"
-          python${{ matrix.python-version }} ci/update_version.py
+          python${{ matrix.python-version }} ci/update_version.py "${GITHUB_REF#refs/tags/v}" --commit "${GITHUB_SHA}"
 
       - name: Build package for Python ${{ matrix.python-version }}
         run: |


### PR DESCRIPTION
## Summary

Fix the publish workflow version update step in the container environment.

## Changes

- Pass the release version from `GITHUB_REF` directly to `ci/update_version.py`.
- Pass the commit SHA from `GITHUB_SHA` instead of calling `git rev-parse HEAD` inside the container.

## Why

The self-hosted container runner can fail when running git commands inside the container. Using GitHub Actions environment variables avoids that dependency.

## Validation

- Locally verified that `ci/update_version.py` writes the expected version and commit when given `GITHUB_REF` and `GITHUB_SHA` values.
